### PR TITLE
Minor updates to bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 
+mkdir -p /vagrant/vendor
 ######### install collectd
-apt-get install -y collectd
-service collectd stop
-ln -sF /vagrant/collectd/collectd.conf /etc/collectd/collectd.conf
+sudo apt-get install -y collectd
+sudo service collectd stop
+ln -sf /vagrant/collectd/collectd.conf /etc/collectd/collectd.conf
 
 ######### install  nginx
-apt-get install -y nginx
-sudo ln -sF /vagrant/nginx/default.conf /etc/nginx/conf.d/default.conf
-sudo ln -sF /vagrant/nginx/log/ /var/log/nginx
+sudo apt-get install -y nginx
+sudo ln -sf /vagrant/nginx/default.conf /etc/nginx/conf.d/default.conf
+sudo ln -sf /vagrant/nginx/log/ /var/log/nginx
 
 ########## install Java 8
 if type -p java; then
@@ -35,8 +36,10 @@ fi
 
 sudo dpkg -i logstash_1.4.2-1-2c0f5a1_all.deb
 sudo dpkg -i logstash-contrib_1.4.2-1-efd53ef_all.deb
-sudo ln -sF /vagrant/logstash/conf.d /etc/logstash/
-sudo ln -sF /vagrant/logstash/log /var/log/lgostash
+
+sudo rm -rf /etc/logstash/conf.d
+sudo ln -sf /vagrant/logstash/conf.d /etc/logstash/
+sudo ln -sf /vagrant/logstash/log /var/log/logstash
 
 ####### install Elasticsearch
 if [ ! -f elasticsearch-1.3.4.deb ]; then
@@ -46,8 +49,8 @@ fi
 sudo dpkg -i elasticsearch-1.3.4.deb
 sudo update-rc.d elasticsearch defaults 95 10
 sudo rm /etc/elasticsearch/*.yml
-sudo ln -sF /vagrant/elasticsearch/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml
-sudo ln -sF /vagrant/elasticsearch/logging.yml /etc/elasticsearch/logging.yml
+sudo ln -sf /vagrant/elasticsearch/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml
+sudo ln -sf /vagrant/elasticsearch/logging.yml /etc/elasticsearch/logging.yml
 
 ###### install Elasticsearch Pugins
 sudo /usr/share/elasticsearch/bin/plugin -i elasticsearch/marvel/latest
@@ -58,24 +61,25 @@ sudo /usr/share/elasticsearch/bin/plugin -i mobz/elasticsearch-head
 ###### Install Kibana
 cd /vagrant/vendor
 # Download if it does not exist
-if [ ! -f kibana-3.1.1.tar.gz]; then
+if [ ! -f kibana-3.1.1.tar.gz ]; then
     echo "Downloading Kibana 3.1.1"
     wget -q --no-check-certificate https://download.elasticsearch.org/kibana/kibana/kibana-3.1.1.tar.gz
 fi
 # Unzip and copy to webserver dir
-tar zxf /vagrant/kibana-3.1.1.tar.gz
-sudo cp -Rf /vagrant/vendor/kibana-3.1.1/* /usr/share/nginx/html/
+tar zxf /vagrant/vendor/kibana-3.1.1.tar.gz
 sudo rm -rf /usr/share/nginx/html/app/dashboards
+sudo cp -Rf /vagrant/vendor/kibana-3.1.1/* /usr/share/nginx/html/
 sudo ln -s /vagrant/kibana/dashboards /usr/share/nginx/html/app/dashboards
 
 ##### install Logstash
-cd /opt
-tar zxf /vagrant/logstash-1.4.1.tar.gz
-ln -sF logstash-1.4.1 logstash
+## Commented out since it is already installed earlier in the script
+#cd /opt
+#sudo tar zxf /vagrant/vendor/logstash-1.4.1.tar.gz
+#sudo ln -sf logstash-1.4.1 logstash
 
 # fix permissions
-chown -R vagrant.vagrant /opt/logstash*
-chown -R vagrant.vagrant /etc/elasticsearch*
+sudo chown -R vagrant.vagrant /opt/logstash*
+sudo chown -R vagrant.vagrant /etc/elasticsearch*
 
 #Clean-up
 #cd /vagrant rm -rf /vendor/*


### PR DESCRIPTION
Found a couple of typos and missing commands causing vagrant initialization to fail - some examples:
- /vagrant/vendor directory never created (even though stuff is being untar'd in it)
- symbolic links to existing files/directories - switched from ln -sF from ln -sf (to force the symlink)
- operations in /opt directory not sudo'd (/opt is owned by root so non-sudo'd stuff failed)
